### PR TITLE
Fix make update script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,11 +349,11 @@ clean-bundle-deps:
 
 update:
 	@echo "Updating Makefile..."
-	@URL=http://github.com/c9s/vim-makefile/raw/master/Makefile ; \
+	@URL=https://raw.githubusercontent.com/c9s/vim-makefile/master/Makefile ; \
 	if [[ -n `which curl` ]]; then \
 		curl $$URL -o Makefile ; \
-	if [[ -n `which wget` ]]; then \
-		wget -c $$URL ; \
+	elif [[ -n `which wget` ]]; then \
+		wget $$URL -O Makefile ; \
 	elif [[ -n `which fetch` ]]; then \
 		fetch $$URL ; \
 	fi

--- a/template/Makefile.tpl
+++ b/template/Makefile.tpl
@@ -325,7 +325,7 @@ clean-bundle-deps:
 
 update:
 	@echo "Updating Makefile..."
-	@URL=http://github.com/c9s/vim-makefile/raw/master/Makefile ; \
+	@URL=https://raw.githubusercontent.com/c9s/vim-makefile/master/Makefile ; \
 	if [[ -n `which curl` ]]; then \
 		curl $$URL -o Makefile ; \
 	elif [[ -n `which wget` ]]; then \

--- a/template/Makefile.tpl
+++ b/template/Makefile.tpl
@@ -329,7 +329,7 @@ update:
 	if [[ -n `which curl` ]]; then \
 		curl $$URL -o Makefile ; \
 	elif [[ -n `which wget` ]]; then \
-		wget -c $$URL ; \
+		wget $$URL -O Makefile ; \
 	elif [[ -n `which fetch` ]]; then \
 		fetch $$URL ; \
 	fi

--- a/template/Makefile.tpl
+++ b/template/Makefile.tpl
@@ -328,7 +328,7 @@ update:
 	@URL=http://github.com/c9s/vim-makefile/raw/master/Makefile ; \
 	if [[ -n `which curl` ]]; then \
 		curl $$URL -o Makefile ; \
-	if [[ -n `which wget` ]]; then \
+	elif [[ -n `which wget` ]]; then \
 		wget -c $$URL ; \
 	elif [[ -n `which fetch` ]]; then \
 		fetch $$URL ; \


### PR DESCRIPTION
Right now, running `make update` has the following issues:
- There is a syntax error relating to an unclosed if block
- The curl command results in an empty file, due to a url redirect
- The wget command fails to overwrite the existing file with the new version